### PR TITLE
Avoid multiple calls to RefreshDetectedYuzuInstallationStateAsync()

### DIFF
--- a/source/EzYuzu/frmMain.cs
+++ b/source/EzYuzu/frmMain.cs
@@ -69,7 +69,7 @@ namespace EzYuzu
 
         private async void CboUpdateChannel_SelectedIndexChangedAsync(object sender, EventArgs e)
         {
-            if (!formHasLoaded)
+            if (!formHasLoaded || !cboUpdateChannel.Enabled)
                 return;
 
             // get branch based on selected index 


### PR DESCRIPTION
Starting EzYuzu with empty `Settings.YuzuLocation` and selecting the directory via `BtnBrowse` will result in multiple calls to the "search for updates routine", from both:

```csharp
private async void CboUpdateChannel_SelectedIndexChangedAsync(object sender, EventArgs e) { ... }
private async void BtnBrowse_ClickAsync(object sender, EventArgs e) { ... }
```

This change add a guard to the `CboUpdateChannel_SelectedIndexChangedAsync` event (similar to what has already been implemented in the `CboUpdateVersion_SelectedIndexChangedAsync` event).

Please consider looking for unexpected behaviours because I'm not 100% familiar with this codebase (yet 😄 ).